### PR TITLE
Making the constructor of the Job class with the IJobRepository parameter public

### DIFF
--- a/src/NBatch.Main/Core/Job.cs
+++ b/src/NBatch.Main/Core/Job.cs
@@ -14,7 +14,7 @@ namespace NBatch.Main.Core
         {
         }
 
-        internal Job(IJobRepository repo)
+        public Job(IJobRepository repo)
         {
             _repo = repo;
             _steps = new Dictionary<string, IStep>();


### PR DESCRIPTION
Making the constructor with the IJobRepository parameter public would make it easier to use NBatch in scenarios where a SQL Db is not used