### PR TITLE
Add PostgreSQL & cross-DB ETL integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         run: dotnet test -c Release --no-build --filter "Category=Docker" --logger "trx;LogFileName=integration-results.trx"
         working-directory: ${{ env.SOLUTION_DIR }}
 
-      - name: Stop SQL Server (docker-compose)
+      - name: Stop databases (docker-compose)
         if: always()
         run: docker compose down -v
         working-directory: ${{ env.SOLUTION_DIR }}

--- a/src/NBatch.Tests/Integration/CrossDatabaseEtlTests.cs
+++ b/src/NBatch.Tests/Integration/CrossDatabaseEtlTests.cs
@@ -1,0 +1,430 @@
+using Microsoft.EntityFrameworkCore;
+using NBatch.Core;
+using NBatch.Core.Interfaces;
+using NBatch.Core.Repositories;
+using NBatch.Readers.DbReader;
+using NBatch.Tests.Integration.Fixtures;
+using NUnit.Framework;
+
+namespace NBatch.Tests.Integration;
+
+/// <summary>
+/// Cross-database ETL integration tests exercising pipelines between SQL Server
+/// and PostgreSQL via docker-compose.
+///
+/// Prerequisites:
+///   cd src &amp;&amp; docker-compose up -d
+///
+/// Run these tests with:
+///   dotnet test --filter "Category=Docker"
+/// </summary>
+[TestFixture]
+[Category("Docker")]
+internal sealed class CrossDatabaseEtlTests
+{
+    private const string SqlServerConnectionString =
+        "Server=localhost,1433;Database=NBatch_IntegrationTests;User Id=sa;Password=@Password1234;TrustServerCertificate=True;";
+
+    private const string PostgreSqlConnectionString =
+        "Host=localhost;Port=5432;Database=nbatch_integration;Username=nbatch;Password=Password1234;";
+
+    private static DbContextOptions<TestDbContext> SqlServerOptions
+        => TestDbContext.ForSqlServer(SqlServerConnectionString);
+
+    private static DbContextOptions<TestDbContext> PostgreSqlOptions
+        => TestDbContext.ForPostgreSql(PostgreSqlConnectionString);
+
+    [SetUp]
+    public void BeforeEach()
+    {
+        EfJobRepository.ResetInitializationCache();
+    }
+
+    [TearDown]
+    public async Task AfterEach()
+    {
+        // Clean ETL destination tables in both databases
+        await using var sqlCtx = new TestDbContext(SqlServerOptions);
+        await sqlCtx.Database.ExecuteSqlRawAsync("DELETE FROM TestRecordEtl");
+
+        await using var pgCtx = new TestDbContext(PostgreSqlOptions);
+        await pgCtx.Database.ExecuteSqlRawAsync(@"DELETE FROM ""TestRecordEtl""");
+    }
+
+    #region Helpers
+
+    private sealed class CollectingWriter<T> : IWriter<T>
+    {
+        public List<T> Written { get; } = [];
+
+        public Task WriteAsync(IEnumerable<T> items, CancellationToken cancellationToken = default)
+        {
+            Written.AddRange(items);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FailAfterNItemsProcessor<TIn, TOut>(int succeedCount, Func<TIn, TOut> transform) : IProcessor<TIn, TOut>
+    {
+        private int _processed;
+
+        public Task<TOut> ProcessAsync(TIn input, CancellationToken cancellationToken = default)
+        {
+            if (_processed >= succeedCount)
+                throw new InvalidOperationException($"Simulated failure after {succeedCount} items");
+            _processed++;
+            return Task.FromResult(transform(input));
+        }
+    }
+
+    private static string UniqueJobName([System.Runtime.CompilerServices.CallerMemberName] string caller = "")
+        => $"{caller}_{Guid.NewGuid():N}";
+
+    private static TestRecordEtl TransformRecord(TestRecord r) => new()
+    {
+        Code = r.Code.ToUpperInvariant(),
+        Value = r.Value * 2,
+        Category = r.Category
+    };
+
+    #endregion
+
+    #region 1 — SQL Server → PostgreSQL ETL
+
+    [Test]
+    public async Task Etl_SqlServer_to_PostgreSql_50K_records()
+    {
+        await using var readCtx = new TestDbContext(SqlServerOptions);
+
+        // Job store on SQL Server; read from SQL Server, write to PostgreSQL
+        var job = Job.CreateBuilder(UniqueJobName())
+            .UseJobStore(SqlServerConnectionString, DatabaseProvider.SqlServer)
+            .AddStep("etl", step => step
+                .ReadFrom(new DbReader<TestRecord>(readCtx, q => q.OrderBy(r => r.Id)))
+                .ProcessWith(TransformRecord)
+                .WriteTo(async (IEnumerable<TestRecordEtl> items, CancellationToken ct) =>
+                {
+                    await using var writeCtx = new TestDbContext(PostgreSqlOptions);
+                    writeCtx.Set<TestRecordEtl>().AddRange(items);
+                    await writeCtx.SaveChangesAsync(ct);
+                })
+                .WithChunkSize(1000))
+            .Build();
+
+        var result = await job.RunAsync();
+
+        Assert.That(result.Success, Is.True);
+        Assert.That(result.Steps[0].ItemsProcessed, Is.EqualTo(50_000));
+
+        // Verify in PostgreSQL
+        await using var verifyCtx = new TestDbContext(PostgreSqlOptions);
+        var count = await verifyCtx.TestRecordEtls.CountAsync();
+        Assert.That(count, Is.EqualTo(50_000));
+
+        var first = await verifyCtx.TestRecordEtls.OrderBy(r => r.Id).FirstAsync();
+        Assert.That(first.Code, Is.EqualTo("REC-00001"));
+        Assert.That(first.Value, Is.EqualTo(1.23m * 2));
+
+        var last = await verifyCtx.TestRecordEtls.OrderByDescending(r => r.Id).FirstAsync();
+        Assert.That(last.Code, Is.EqualTo("REC-50000"));
+    }
+
+    #endregion
+
+    #region 2 — PostgreSQL → SQL Server ETL
+
+    [Test]
+    public async Task Etl_PostgreSql_to_SqlServer_50K_records()
+    {
+        await using var readCtx = new TestDbContext(PostgreSqlOptions);
+
+        // Job store on PostgreSQL; read from PostgreSQL, write to SQL Server
+        var job = Job.CreateBuilder(UniqueJobName())
+            .UseJobStore(PostgreSqlConnectionString, DatabaseProvider.PostgreSql)
+            .AddStep("etl", step => step
+                .ReadFrom(new DbReader<TestRecord>(readCtx, q => q.OrderBy(r => r.Id)))
+                .ProcessWith(TransformRecord)
+                .WriteTo(async (IEnumerable<TestRecordEtl> items, CancellationToken ct) =>
+                {
+                    await using var writeCtx = new TestDbContext(SqlServerOptions);
+                    writeCtx.Set<TestRecordEtl>().AddRange(items);
+                    await writeCtx.SaveChangesAsync(ct);
+                })
+                .WithChunkSize(1000))
+            .Build();
+
+        var result = await job.RunAsync();
+
+        Assert.That(result.Success, Is.True);
+        Assert.That(result.Steps[0].ItemsProcessed, Is.EqualTo(50_000));
+
+        // Verify in SQL Server
+        await using var verifyCtx = new TestDbContext(SqlServerOptions);
+        var count = await verifyCtx.TestRecordEtls.CountAsync();
+        Assert.That(count, Is.EqualTo(50_000));
+
+        var first = await verifyCtx.TestRecordEtls.OrderBy(r => r.Id).FirstAsync();
+        Assert.That(first.Code, Is.EqualTo("REC-00001"));
+        Assert.That(first.Value, Is.EqualTo(1.23m * 2));
+    }
+
+    #endregion
+
+    #region 3 — Cross-DB ETL with filtered subset
+
+    [Test]
+    public async Task Etl_SqlServer_to_PostgreSql_filtered_category()
+    {
+        await using var readCtx = new TestDbContext(SqlServerOptions);
+
+        // Only transfer "Gamma" records (10,000 of 50,000)
+        var job = Job.CreateBuilder(UniqueJobName())
+            .UseJobStore(SqlServerConnectionString, DatabaseProvider.SqlServer)
+            .AddStep("etl-gamma", step => step
+                .ReadFrom(new DbReader<TestRecord>(readCtx,
+                    q => q.Where(r => r.Category == "Gamma").OrderBy(r => r.Id)))
+                .ProcessWith(TransformRecord)
+                .WriteTo(async (IEnumerable<TestRecordEtl> items, CancellationToken ct) =>
+                {
+                    await using var writeCtx = new TestDbContext(PostgreSqlOptions);
+                    writeCtx.Set<TestRecordEtl>().AddRange(items);
+                    await writeCtx.SaveChangesAsync(ct);
+                })
+                .WithChunkSize(500))
+            .Build();
+
+        var result = await job.RunAsync();
+
+        Assert.That(result.Success, Is.True);
+        Assert.That(result.Steps[0].ItemsProcessed, Is.EqualTo(10_000));
+
+        await using var verifyCtx = new TestDbContext(PostgreSqlOptions);
+        var count = await verifyCtx.TestRecordEtls.CountAsync();
+        Assert.That(count, Is.EqualTo(10_000));
+        Assert.That(await verifyCtx.TestRecordEtls.AllAsync(r => r.Category == "Gamma"), Is.True);
+    }
+
+    #endregion
+
+    #region 4 — Cross-DB ETL restart from failure
+
+    [Test]
+    public async Task Etl_cross_db_restart_from_failure()
+    {
+        var jobName = UniqueJobName();
+
+        // Run 1: Transfer 5000 items then fail.
+        // Processor succeeds for first 5000 items, then throws.
+        await using (var readCtx1 = new TestDbContext(SqlServerOptions))
+        {
+            var job1 = Job.CreateBuilder(jobName)
+                .UseJobStore(SqlServerConnectionString, DatabaseProvider.SqlServer)
+                .AddStep("etl", step => step
+                    .ReadFrom(new DbReader<TestRecord>(readCtx1, q => q.OrderBy(r => r.Id)))
+                    .ProcessWith(new FailAfterNItemsProcessor<TestRecord, TestRecordEtl>(
+                        succeedCount: 5000, TransformRecord))
+                    .WriteTo(async (IEnumerable<TestRecordEtl> items, CancellationToken ct) =>
+                    {
+                        await using var writeCtx = new TestDbContext(PostgreSqlOptions);
+                        writeCtx.Set<TestRecordEtl>().AddRange(items);
+                        await writeCtx.SaveChangesAsync(ct);
+                    })
+                    .WithChunkSize(1000))
+                .Build();
+
+            var result1 = await job1.RunAsync();
+            Assert.That(result1.Success, Is.False);
+        }
+
+        // Verify partial write to PostgreSQL (5 full chunks of 1000)
+        await using (var verifyCtx = new TestDbContext(PostgreSqlOptions))
+        {
+            var partialCount = await verifyCtx.TestRecordEtls.CountAsync();
+            Assert.That(partialCount, Is.EqualTo(5000));
+        }
+
+        // Run 2: Restart with a processor that always succeeds.
+        // Should resume from the failed chunk (index 5000) and transfer remaining 45,000.
+        await using (var readCtx2 = new TestDbContext(SqlServerOptions))
+        {
+            var job2 = Job.CreateBuilder(jobName)
+                .UseJobStore(SqlServerConnectionString, DatabaseProvider.SqlServer)
+                .AddStep("etl", step => step
+                    .ReadFrom(new DbReader<TestRecord>(readCtx2, q => q.OrderBy(r => r.Id)))
+                    .ProcessWith(TransformRecord)
+                    .WriteTo(async (IEnumerable<TestRecordEtl> items, CancellationToken ct) =>
+                    {
+                        await using var writeCtx = new TestDbContext(PostgreSqlOptions);
+                        writeCtx.Set<TestRecordEtl>().AddRange(items);
+                        await writeCtx.SaveChangesAsync(ct);
+                    })
+                    .WithChunkSize(1000))
+                .Build();
+
+            var result2 = await job2.RunAsync();
+            Assert.That(result2.Success, Is.True);
+        }
+
+        // Verify all 50,000 records in PostgreSQL
+        await using (var verifyCtx = new TestDbContext(PostgreSqlOptions))
+        {
+            var totalCount = await verifyCtx.TestRecordEtls.CountAsync();
+            Assert.That(totalCount, Is.EqualTo(50_000));
+        }
+    }
+
+    #endregion
+
+    #region 5 — Multi-step cross-DB pipeline
+
+    [Test]
+    public async Task Multi_step_cross_db_pipeline()
+    {
+        var alphaWriter = new CollectingWriter<TestRecordEtl>();
+        bool notifyExecuted = false;
+
+        await using var sqlCtx = new TestDbContext(SqlServerOptions);
+        await using var pgCtx = new TestDbContext(PostgreSqlOptions);
+
+        // Step 1: Read "Alpha" from SQL Server → collect in memory
+        // Step 2: Read "Beta" from PostgreSQL → write to SQL Server ETL table
+        // Step 3: Tasklet notification
+        var job = Job.CreateBuilder(UniqueJobName())
+            .UseJobStore(SqlServerConnectionString, DatabaseProvider.SqlServer)
+            .AddStep("alpha-from-sql", step => step
+                .ReadFrom(new DbReader<TestRecord>(sqlCtx,
+                    q => q.Where(r => r.Category == "Alpha").OrderBy(r => r.Id)))
+                .ProcessWith(TransformRecord)
+                .WriteTo(alphaWriter)
+                .WithChunkSize(1000))
+            .AddStep("beta-from-pg", step => step
+                .ReadFrom(new DbReader<TestRecord>(pgCtx,
+                    q => q.Where(r => r.Category == "Beta").OrderBy(r => r.Id)))
+                .ProcessWith(TransformRecord)
+                .WriteTo(async (IEnumerable<TestRecordEtl> items, CancellationToken ct) =>
+                {
+                    await using var writeCtx = new TestDbContext(SqlServerOptions);
+                    writeCtx.Set<TestRecordEtl>().AddRange(items);
+                    await writeCtx.SaveChangesAsync(ct);
+                })
+                .WithChunkSize(1000))
+            .AddStep("notify", step => step
+                .Execute(() =>
+                {
+                    notifyExecuted = true;
+                    return Task.CompletedTask;
+                }))
+            .Build();
+
+        var result = await job.RunAsync();
+
+        Assert.That(result.Success, Is.True);
+        Assert.That(result.Steps, Has.Count.EqualTo(3));
+
+        // Step 1: 10,000 Alpha records from SQL Server
+        Assert.That(alphaWriter.Written, Has.Count.EqualTo(10_000));
+        Assert.That(alphaWriter.Written.All(r => r.Category == "Alpha"), Is.True);
+
+        // Step 2: 10,000 Beta records from PostgreSQL → SQL Server ETL table
+        await using var verifyCtx = new TestDbContext(SqlServerOptions);
+        var betaCount = await verifyCtx.TestRecordEtls.CountAsync();
+        Assert.That(betaCount, Is.EqualTo(10_000));
+        Assert.That(await verifyCtx.TestRecordEtls.AllAsync(r => r.Category == "Beta"), Is.True);
+
+        // Step 3: tasklet ran
+        Assert.That(notifyExecuted, Is.True);
+    }
+
+    #endregion
+
+    #region 6 — Bidirectional ETL (swap data between databases)
+
+    [Test]
+    public async Task Bidirectional_etl_swaps_categories_between_databases()
+    {
+        // Transfer "Delta" from SQL Server → PostgreSQL ETL table
+        // Transfer "Epsilon" from PostgreSQL → SQL Server ETL table
+        await using var sqlReadCtx = new TestDbContext(SqlServerOptions);
+        await using var pgReadCtx = new TestDbContext(PostgreSqlOptions);
+
+        var job = Job.CreateBuilder(UniqueJobName())
+            .UseJobStore(SqlServerConnectionString, DatabaseProvider.SqlServer)
+            .AddStep("delta-to-pg", step => step
+                .ReadFrom(new DbReader<TestRecord>(sqlReadCtx,
+                    q => q.Where(r => r.Category == "Delta").OrderBy(r => r.Id)))
+                .ProcessWith(TransformRecord)
+                .WriteTo(async (IEnumerable<TestRecordEtl> items, CancellationToken ct) =>
+                {
+                    await using var writeCtx = new TestDbContext(PostgreSqlOptions);
+                    writeCtx.Set<TestRecordEtl>().AddRange(items);
+                    await writeCtx.SaveChangesAsync(ct);
+                })
+                .WithChunkSize(1000))
+            .AddStep("epsilon-to-sql", step => step
+                .ReadFrom(new DbReader<TestRecord>(pgReadCtx,
+                    q => q.Where(r => r.Category == "Epsilon").OrderBy(r => r.Id)))
+                .ProcessWith(TransformRecord)
+                .WriteTo(async (IEnumerable<TestRecordEtl> items, CancellationToken ct) =>
+                {
+                    await using var writeCtx = new TestDbContext(SqlServerOptions);
+                    writeCtx.Set<TestRecordEtl>().AddRange(items);
+                    await writeCtx.SaveChangesAsync(ct);
+                })
+                .WithChunkSize(1000))
+            .Build();
+
+        var result = await job.RunAsync();
+
+        Assert.That(result.Success, Is.True);
+        Assert.That(result.Steps, Has.Count.EqualTo(2));
+
+        // Verify Delta in PostgreSQL
+        await using var pgVerify = new TestDbContext(PostgreSqlOptions);
+        var deltaCount = await pgVerify.TestRecordEtls.CountAsync();
+        Assert.That(deltaCount, Is.EqualTo(10_000));
+        Assert.That(await pgVerify.TestRecordEtls.AllAsync(r => r.Category == "Delta"), Is.True);
+
+        // Verify Epsilon in SQL Server
+        await using var sqlVerify = new TestDbContext(SqlServerOptions);
+        var epsilonCount = await sqlVerify.TestRecordEtls.CountAsync();
+        Assert.That(epsilonCount, Is.EqualTo(10_000));
+        Assert.That(await sqlVerify.TestRecordEtls.AllAsync(r => r.Category == "Epsilon"), Is.True);
+    }
+
+    #endregion
+
+    #region 7 — Cross-DB ETL with job store on the opposite provider
+
+    [Test]
+    public async Task Etl_SqlServer_to_PostgreSql_with_job_store_on_PostgreSql()
+    {
+        await using var readCtx = new TestDbContext(SqlServerOptions);
+
+        // Job store on PostgreSQL, data flows SQL Server → PostgreSQL
+        var job = Job.CreateBuilder(UniqueJobName())
+            .UseJobStore(PostgreSqlConnectionString, DatabaseProvider.PostgreSql)
+            .AddStep("etl", step => step
+                .ReadFrom(new DbReader<TestRecord>(readCtx,
+                    q => q.Where(r => r.Category == "Alpha").OrderBy(r => r.Id)))
+                .ProcessWith(TransformRecord)
+                .WriteTo(async (IEnumerable<TestRecordEtl> items, CancellationToken ct) =>
+                {
+                    await using var writeCtx = new TestDbContext(PostgreSqlOptions);
+                    writeCtx.Set<TestRecordEtl>().AddRange(items);
+                    await writeCtx.SaveChangesAsync(ct);
+                })
+                .WithChunkSize(500))
+            .Build();
+
+        var result = await job.RunAsync();
+
+        Assert.That(result.Success, Is.True);
+        Assert.That(result.Steps[0].ItemsProcessed, Is.EqualTo(10_000));
+
+        await using var verifyCtx = new TestDbContext(PostgreSqlOptions);
+        var count = await verifyCtx.TestRecordEtls.CountAsync();
+        Assert.That(count, Is.EqualTo(10_000));
+    }
+
+    #endregion
+}

--- a/src/NBatch.Tests/Integration/Fixtures/TestDbContext.cs
+++ b/src/NBatch.Tests/Integration/Fixtures/TestDbContext.cs
@@ -1,0 +1,46 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace NBatch.Tests.Integration.Fixtures;
+
+/// <summary>
+/// EF Core DbContext for integration test data.
+/// Configurable for SQL Server or PostgreSQL via static factory methods.
+/// </summary>
+internal sealed class TestDbContext(DbContextOptions<TestDbContext> options) : DbContext(options)
+{
+    public DbSet<TestRecord> TestRecords => Set<TestRecord>();
+    public DbSet<TestRecordEtl> TestRecordEtls => Set<TestRecordEtl>();
+
+    internal static DbContextOptions<TestDbContext> ForSqlServer(string connectionString)
+        => new DbContextOptionsBuilder<TestDbContext>()
+            .UseSqlServer(connectionString)
+            .Options;
+
+    internal static DbContextOptions<TestDbContext> ForPostgreSql(string connectionString)
+        => new DbContextOptionsBuilder<TestDbContext>()
+            .UseNpgsql(connectionString)
+            .Options;
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<TestRecord>(entity =>
+        {
+            entity.ToTable("TestRecord");
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).ValueGeneratedOnAdd();
+            entity.Property(e => e.Code).HasMaxLength(50);
+            entity.Property(e => e.Value).HasPrecision(18, 2);
+            entity.Property(e => e.Category).HasMaxLength(50);
+        });
+
+        modelBuilder.Entity<TestRecordEtl>(entity =>
+        {
+            entity.ToTable("TestRecordEtl");
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).ValueGeneratedOnAdd();
+            entity.Property(e => e.Code).HasMaxLength(50);
+            entity.Property(e => e.Value).HasPrecision(18, 2);
+            entity.Property(e => e.Category).HasMaxLength(50);
+        });
+    }
+}

--- a/src/NBatch.Tests/Integration/Fixtures/TestRecord.cs
+++ b/src/NBatch.Tests/Integration/Fixtures/TestRecord.cs
@@ -1,0 +1,25 @@
+namespace NBatch.Tests.Integration.Fixtures;
+
+/// <summary>
+/// Source entity mapped to the TestRecord table seeded with 50,000 rows
+/// by the init SQL scripts.
+/// </summary>
+internal sealed class TestRecord
+{
+    public int Id { get; set; }
+    public string Code { get; set; } = "";
+    public decimal Value { get; set; }
+    public string Category { get; set; } = "";
+}
+
+/// <summary>
+/// Destination entity for cross-database ETL tests.
+/// Mapped to the TestRecordEtl table (created empty by init scripts).
+/// </summary>
+internal sealed class TestRecordEtl
+{
+    public int Id { get; set; }
+    public string Code { get; set; } = "";
+    public decimal Value { get; set; }
+    public string Category { get; set; } = "";
+}

--- a/src/NBatch.Tests/Integration/PostgreSqlIntegrationTests.cs
+++ b/src/NBatch.Tests/Integration/PostgreSqlIntegrationTests.cs
@@ -1,0 +1,586 @@
+using Microsoft.EntityFrameworkCore;
+using NBatch.Core;
+using NBatch.Core.Interfaces;
+using NBatch.Core.Repositories;
+using NBatch.Readers.DbReader;
+using NBatch.Tests.Integration.Fixtures;
+using NUnit.Framework;
+
+namespace NBatch.Tests.Integration;
+
+/// <summary>
+/// Integration tests that run against a real PostgreSQL instance via docker-compose.
+///
+/// Prerequisites:
+///   cd src &amp;&amp; docker-compose up -d
+///
+/// Run these tests with:
+///   dotnet test --filter "Category=Docker"
+/// </summary>
+[TestFixture]
+[Category("Docker")]
+internal sealed class PostgreSqlIntegrationTests
+{
+    private const string ConnectionString =
+        "Host=localhost;Port=5432;Database=nbatch_integration;Username=nbatch;Password=Password1234;";
+
+    [SetUp]
+    public void BeforeEach()
+    {
+        EfJobRepository.ResetInitializationCache();
+    }
+
+    #region Helpers
+
+    private sealed class ListReader<T>(IReadOnlyList<T> items) : IReader<T>
+    {
+        public Task<IEnumerable<T>> ReadAsync(long startIndex, int chunkSize, CancellationToken cancellationToken = default)
+        {
+            var chunk = items.Skip((int)startIndex).Take(chunkSize);
+            return Task.FromResult(chunk);
+        }
+    }
+
+    private sealed class CollectingWriter<T> : IWriter<T>
+    {
+        public List<T> Written { get; } = [];
+
+        public Task WriteAsync(IEnumerable<T> items, CancellationToken cancellationToken = default)
+        {
+            Written.AddRange(items);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FailOnceAtIndexReader<T>(IReadOnlyList<T> items, long failAtIndex) : IReader<T>
+    {
+        private bool _hasFailed;
+
+        public Task<IEnumerable<T>> ReadAsync(long startIndex, int chunkSize, CancellationToken cancellationToken = default)
+        {
+            if (!_hasFailed && startIndex == failAtIndex)
+            {
+                _hasFailed = true;
+                throw new InvalidOperationException($"Simulated failure at index {failAtIndex}");
+            }
+
+            var chunk = items.Skip((int)startIndex).Take(chunkSize);
+            return Task.FromResult(chunk);
+        }
+    }
+
+    private sealed class FailNTimesProcessor<T>(int failCount) : IProcessor<T, T>
+    {
+        private int _calls;
+
+        public Task<T> ProcessAsync(T input, CancellationToken cancellationToken = default)
+        {
+            if (++_calls <= failCount)
+                throw new TimeoutException($"Transient failure #{_calls}");
+            return Task.FromResult(input);
+        }
+    }
+
+    private sealed class FailAfterNItemsProcessor<T>(int succeedCount) : IProcessor<T, T>
+    {
+        private int _processed;
+
+        public Task<T> ProcessAsync(T input, CancellationToken cancellationToken = default)
+        {
+            if (_processed >= succeedCount)
+                throw new InvalidOperationException($"Simulated failure after {succeedCount} items");
+            _processed++;
+            return Task.FromResult(input);
+        }
+    }
+
+    private static string UniqueJobName([System.Runtime.CompilerServices.CallerMemberName] string caller = "")
+        => $"{caller}_{Guid.NewGuid():N}";
+
+    private static DbContextOptions<TestDbContext> PgOptions
+        => TestDbContext.ForPostgreSql(ConnectionString);
+
+    private async Task TruncateEtlTableAsync()
+    {
+        await using var ctx = new TestDbContext(PgOptions);
+        await ctx.Database.ExecuteSqlRawAsync(@"DELETE FROM ""TestRecordEtl""");
+    }
+
+    #endregion
+
+    #region 1 — Basic chunk processing with PostgreSQL
+
+    [Test]
+    public async Task Job_processes_all_chunks_with_PostgreSql()
+    {
+        var data = new[] { "a", "b", "c", "d", "e" };
+        var writer = new CollectingWriter<string>();
+
+        var job = Job.CreateBuilder(UniqueJobName())
+            .UseJobStore(ConnectionString, DatabaseProvider.PostgreSql)
+            .AddStep("step1", step => step
+                .ReadFrom(new ListReader<string>(data))
+                .WriteTo(writer)
+                .WithChunkSize(2))
+            .Build();
+
+        var result = await job.RunAsync();
+
+        Assert.That(result.Success, Is.True);
+        Assert.That(writer.Written, Is.EqualTo(new[] { "a", "b", "c", "d", "e" }));
+        Assert.That(result.Steps[0].ItemsRead, Is.EqualTo(5));
+        Assert.That(result.Steps[0].ItemsProcessed, Is.EqualTo(5));
+    }
+
+    #endregion
+
+    #region 2 — Restart from failure with PostgreSQL
+
+    [Test]
+    public async Task Job_restart_resumes_from_failed_chunk_with_PostgreSql()
+    {
+        var data = new[] { "a", "b", "c", "d" };
+        var jobName = UniqueJobName();
+
+        var failReader = new FailOnceAtIndexReader<string>(data, failAtIndex: 2);
+        var writer = new CollectingWriter<string>();
+
+        var job1 = Job.CreateBuilder(jobName)
+            .UseJobStore(ConnectionString, DatabaseProvider.PostgreSql)
+            .AddStep("step1", step => step
+                .ReadFrom(failReader)
+                .WriteTo(writer)
+                .WithChunkSize(2))
+            .Build();
+
+        var result1 = await job1.RunAsync();
+        Assert.That(result1.Success, Is.False);
+        Assert.That(writer.Written, Is.EqualTo(new[] { "a", "b" }));
+
+        var job2 = Job.CreateBuilder(jobName)
+            .UseJobStore(ConnectionString, DatabaseProvider.PostgreSql)
+            .AddStep("step1", step => step
+                .ReadFrom(failReader)
+                .WriteTo(writer)
+                .WithChunkSize(2))
+            .Build();
+
+        var result2 = await job2.RunAsync();
+
+        Assert.That(result2.Success, Is.True);
+        Assert.That(writer.Written, Is.EqualTo(new[] { "a", "b", "c", "d" }));
+    }
+
+    #endregion
+
+    #region 3 — Skip policy with PostgreSQL
+
+    [Test]
+    public async Task Skip_policy_works_with_PostgreSql()
+    {
+        var data = new[] { "a", "b" };
+        var processor = new FailNTimesProcessor<string>(failCount: 1);
+        var skipPolicy = new SkipPolicy([typeof(TimeoutException)], skipLimit: 2);
+        var writer = new CollectingWriter<string>();
+
+        var job = Job.CreateBuilder(UniqueJobName())
+            .UseJobStore(ConnectionString, DatabaseProvider.PostgreSql)
+            .AddStep("step1", step => step
+                .ReadFrom(new ListReader<string>(data))
+                .ProcessWith(processor)
+                .WriteTo(writer)
+                .WithSkipPolicy(skipPolicy)
+                .WithChunkSize(1))
+            .Build();
+
+        var result = await job.RunAsync();
+
+        Assert.That(result.Success, Is.True);
+        Assert.That(result.Steps[0].ErrorsSkipped, Is.EqualTo(1));
+        Assert.That(writer.Written, Is.EqualTo(new[] { "b" }));
+    }
+
+    #endregion
+
+    #region 4 — Large dataset (50K records from PostgreSQL DB)
+
+    [Test]
+    public async Task Large_dataset_50K_records_chunk500_PostgreSql()
+    {
+        await using var ctx = new TestDbContext(PgOptions);
+        var writer = new CollectingWriter<TestRecord>();
+
+        var job = Job.CreateBuilder(UniqueJobName())
+            .UseJobStore(ConnectionString, DatabaseProvider.PostgreSql)
+            .AddStep("read-all", step => step
+                .ReadFrom(new DbReader<TestRecord>(ctx, q => q.OrderBy(r => r.Id)))
+                .WriteTo(writer)
+                .WithChunkSize(500))
+            .Build();
+
+        var result = await job.RunAsync();
+
+        Assert.That(result.Success, Is.True);
+        Assert.That(result.Steps[0].ItemsRead, Is.EqualTo(50_000));
+        Assert.That(writer.Written, Has.Count.EqualTo(50_000));
+        Assert.That(writer.Written[0].Code, Is.EqualTo("REC-00001"));
+        Assert.That(writer.Written[^1].Code, Is.EqualTo("REC-50000"));
+    }
+
+    [Test]
+    public async Task Large_dataset_exact_chunk_boundary_chunk1000_PostgreSql()
+    {
+        await using var ctx = new TestDbContext(PgOptions);
+        var writer = new CollectingWriter<TestRecord>();
+
+        var job = Job.CreateBuilder(UniqueJobName())
+            .UseJobStore(ConnectionString, DatabaseProvider.PostgreSql)
+            .AddStep("read-all", step => step
+                .ReadFrom(new DbReader<TestRecord>(ctx, q => q.OrderBy(r => r.Id)))
+                .WriteTo(writer)
+                .WithChunkSize(1000))
+            .Build();
+
+        var result = await job.RunAsync();
+
+        Assert.That(result.Success, Is.True);
+        Assert.That(writer.Written, Has.Count.EqualTo(50_000));
+    }
+
+    [Test]
+    public async Task Large_dataset_uneven_chunk_boundary_chunk499_PostgreSql()
+    {
+        await using var ctx = new TestDbContext(PgOptions);
+        var writer = new CollectingWriter<TestRecord>();
+
+        var job = Job.CreateBuilder(UniqueJobName())
+            .UseJobStore(ConnectionString, DatabaseProvider.PostgreSql)
+            .AddStep("read-all", step => step
+                .ReadFrom(new DbReader<TestRecord>(ctx, q => q.OrderBy(r => r.Id)))
+                .WriteTo(writer)
+                .WithChunkSize(499))
+            .Build();
+
+        var result = await job.RunAsync();
+
+        Assert.That(result.Success, Is.True);
+        Assert.That(writer.Written, Has.Count.EqualTo(50_000));
+    }
+
+    [Test]
+    public async Task Large_dataset_single_chunk_PostgreSql()
+    {
+        await using var ctx = new TestDbContext(PgOptions);
+        var writer = new CollectingWriter<TestRecord>();
+
+        var job = Job.CreateBuilder(UniqueJobName())
+            .UseJobStore(ConnectionString, DatabaseProvider.PostgreSql)
+            .AddStep("read-all", step => step
+                .ReadFrom(new DbReader<TestRecord>(ctx, q => q.OrderBy(r => r.Id)))
+                .WriteTo(writer)
+                .WithChunkSize(50_000))
+            .Build();
+
+        var result = await job.RunAsync();
+
+        Assert.That(result.Success, Is.True);
+        Assert.That(writer.Written, Has.Count.EqualTo(50_000));
+    }
+
+    [Test]
+    public async Task Large_dataset_oversized_chunk_PostgreSql()
+    {
+        await using var ctx = new TestDbContext(PgOptions);
+        var writer = new CollectingWriter<TestRecord>();
+
+        var job = Job.CreateBuilder(UniqueJobName())
+            .UseJobStore(ConnectionString, DatabaseProvider.PostgreSql)
+            .AddStep("read-all", step => step
+                .ReadFrom(new DbReader<TestRecord>(ctx, q => q.OrderBy(r => r.Id)))
+                .WriteTo(writer)
+                .WithChunkSize(100_000))
+            .Build();
+
+        var result = await job.RunAsync();
+
+        Assert.That(result.Success, Is.True);
+        Assert.That(writer.Written, Has.Count.EqualTo(50_000));
+    }
+
+    [Test]
+    public async Task Large_dataset_filtered_by_category_PostgreSql()
+    {
+        await using var ctx = new TestDbContext(PgOptions);
+        var writer = new CollectingWriter<TestRecord>();
+
+        var job = Job.CreateBuilder(UniqueJobName())
+            .UseJobStore(ConnectionString, DatabaseProvider.PostgreSql)
+            .AddStep("read-alpha", step => step
+                .ReadFrom(new DbReader<TestRecord>(ctx,
+                    q => q.Where(r => r.Category == "Alpha").OrderBy(r => r.Id)))
+                .WriteTo(writer)
+                .WithChunkSize(500))
+            .Build();
+
+        var result = await job.RunAsync();
+
+        Assert.That(result.Success, Is.True);
+        Assert.That(writer.Written, Has.Count.EqualTo(10_000));
+        Assert.That(writer.Written.All(r => r.Category == "Alpha"), Is.True);
+    }
+
+    [Test]
+    public async Task Large_dataset_empty_result_set_PostgreSql()
+    {
+        await using var ctx = new TestDbContext(PgOptions);
+        var writer = new CollectingWriter<TestRecord>();
+
+        var job = Job.CreateBuilder(UniqueJobName())
+            .UseJobStore(ConnectionString, DatabaseProvider.PostgreSql)
+            .AddStep("read-none", step => step
+                .ReadFrom(new DbReader<TestRecord>(ctx,
+                    q => q.Where(r => r.Category == "NonExistent").OrderBy(r => r.Id)))
+                .WriteTo(writer)
+                .WithChunkSize(500))
+            .Build();
+
+        var result = await job.RunAsync();
+
+        Assert.That(result.Success, Is.True);
+        Assert.That(result.Steps[0].ItemsRead, Is.EqualTo(0));
+        Assert.That(writer.Written, Is.Empty);
+    }
+
+    #endregion
+
+    #region 5 — Large dataset with transformation (PostgreSQL)
+
+    [Test]
+    public async Task Large_dataset_with_processor_PostgreSql()
+    {
+        await using var ctx = new TestDbContext(PgOptions);
+        var writer = new CollectingWriter<TestRecordEtl>();
+
+        var job = Job.CreateBuilder(UniqueJobName())
+            .UseJobStore(ConnectionString, DatabaseProvider.PostgreSql)
+            .AddStep("transform", step => step
+                .ReadFrom(new DbReader<TestRecord>(ctx, q => q.OrderBy(r => r.Id)))
+                .ProcessWith(r => new TestRecordEtl
+                {
+                    Code = r.Code.ToUpperInvariant(),
+                    Value = r.Value * 2,
+                    Category = r.Category
+                })
+                .WriteTo(writer)
+                .WithChunkSize(1000))
+            .Build();
+
+        var result = await job.RunAsync();
+
+        Assert.That(result.Success, Is.True);
+        Assert.That(writer.Written, Has.Count.EqualTo(50_000));
+        Assert.That(writer.Written[0].Code, Is.EqualTo("REC-00001"));
+        Assert.That(writer.Written[0].Value, Is.EqualTo(1.23m * 2));
+    }
+
+    #endregion
+
+    #region 6 — Large dataset restart (PostgreSQL)
+
+    [Test]
+    public async Task Large_dataset_restart_from_processor_failure_PostgreSql()
+    {
+        var jobName = UniqueJobName();
+
+        var writer1 = new CollectingWriter<TestRecord>();
+        await using (var ctx1 = new TestDbContext(PgOptions))
+        {
+            var job1 = Job.CreateBuilder(jobName)
+                .UseJobStore(ConnectionString, DatabaseProvider.PostgreSql)
+                .AddStep("step1", step => step
+                    .ReadFrom(new DbReader<TestRecord>(ctx1, q => q.OrderBy(r => r.Id)))
+                    .ProcessWith(new FailAfterNItemsProcessor<TestRecord>(succeedCount: 5000))
+                    .WriteTo(writer1)
+                    .WithChunkSize(1000))
+                .Build();
+
+            var result1 = await job1.RunAsync();
+            Assert.That(result1.Success, Is.False);
+            Assert.That(writer1.Written, Has.Count.EqualTo(5000));
+        }
+
+        var writer2 = new CollectingWriter<TestRecord>();
+        await using (var ctx2 = new TestDbContext(PgOptions))
+        {
+            var job2 = Job.CreateBuilder(jobName)
+                .UseJobStore(ConnectionString, DatabaseProvider.PostgreSql)
+                .AddStep("step1", step => step
+                    .ReadFrom(new DbReader<TestRecord>(ctx2, q => q.OrderBy(r => r.Id)))
+                    .WriteTo(writer2)
+                    .WithChunkSize(1000))
+                .Build();
+
+            var result2 = await job2.RunAsync();
+            Assert.That(result2.Success, Is.True);
+            Assert.That(writer2.Written, Has.Count.EqualTo(45_000));
+            Assert.That(writer2.Written[0].Code, Is.EqualTo("REC-05001"));
+        }
+    }
+
+    #endregion
+
+    #region 7 — Large dataset DB-to-DB ETL within PostgreSQL
+
+    [Test]
+    public async Task Large_dataset_db_to_db_etl_within_PostgreSql()
+    {
+        await TruncateEtlTableAsync();
+
+        await using var readCtx = new TestDbContext(PgOptions);
+
+        var job = Job.CreateBuilder(UniqueJobName())
+            .UseJobStore(ConnectionString, DatabaseProvider.PostgreSql)
+            .AddStep("etl", step => step
+                .ReadFrom(new DbReader<TestRecord>(readCtx, q => q.OrderBy(r => r.Id)))
+                .ProcessWith(r => new TestRecordEtl
+                {
+                    Code = r.Code.ToUpperInvariant(),
+                    Value = r.Value * 2,
+                    Category = r.Category
+                })
+                .WriteTo(async (IEnumerable<TestRecordEtl> items, CancellationToken ct) =>
+                {
+                    await using var writeCtx = new TestDbContext(PgOptions);
+                    writeCtx.Set<TestRecordEtl>().AddRange(items);
+                    await writeCtx.SaveChangesAsync(ct);
+                })
+                .WithChunkSize(1000))
+            .Build();
+
+        var result = await job.RunAsync();
+        Assert.That(result.Success, Is.True);
+        Assert.That(result.Steps[0].ItemsProcessed, Is.EqualTo(50_000));
+
+        await using var verifyCtx = new TestDbContext(PgOptions);
+        var etlCount = await verifyCtx.TestRecordEtls.CountAsync();
+        Assert.That(etlCount, Is.EqualTo(50_000));
+
+        var first = await verifyCtx.TestRecordEtls.OrderBy(r => r.Id).FirstAsync();
+        Assert.That(first.Code, Is.EqualTo("REC-00001"));
+        Assert.That(first.Value, Is.EqualTo(1.23m * 2));
+
+        await TruncateEtlTableAsync();
+    }
+
+    #endregion
+
+    #region 8 — Tasklet steps with PostgreSQL
+
+    [Test]
+    public async Task Tasklet_step_success_recorded_with_PostgreSql()
+    {
+        bool executed = false;
+
+        var job = Job.CreateBuilder(UniqueJobName())
+            .UseJobStore(ConnectionString, DatabaseProvider.PostgreSql)
+            .AddStep("tasklet", step => step
+                .Execute(() =>
+                {
+                    executed = true;
+                    return Task.CompletedTask;
+                }))
+            .Build();
+
+        var result = await job.RunAsync();
+
+        Assert.That(result.Success, Is.True);
+        Assert.That(executed, Is.True);
+    }
+
+    [Test]
+    public async Task Tasklet_step_failure_recorded_with_PostgreSql()
+    {
+        var job = Job.CreateBuilder(UniqueJobName())
+            .UseJobStore(ConnectionString, DatabaseProvider.PostgreSql)
+            .AddStep("tasklet", step => step
+                .Execute(() => throw new InvalidOperationException("boom")))
+            .Build();
+
+        var result = await job.RunAsync();
+
+        Assert.That(result.Success, Is.False);
+    }
+
+    #endregion
+
+    #region 9 — Cancellation with PostgreSQL
+
+    [Test]
+    public async Task Cancellation_stops_large_job_PostgreSql()
+    {
+        await using var ctx = new TestDbContext(PgOptions);
+        var cts = new CancellationTokenSource();
+        int chunksWritten = 0;
+
+        var job = Job.CreateBuilder(UniqueJobName())
+            .UseJobStore(ConnectionString, DatabaseProvider.PostgreSql)
+            .AddStep("read-all", step => step
+                .ReadFrom(new DbReader<TestRecord>(ctx, q => q.OrderBy(r => r.Id)))
+                .WriteTo(async (IEnumerable<TestRecord> items, CancellationToken ct) =>
+                {
+                    if (Interlocked.Increment(ref chunksWritten) >= 3)
+                        await cts.CancelAsync();
+                })
+                .WithChunkSize(1000))
+            .Build();
+
+        Assert.ThrowsAsync<OperationCanceledException>(() => job.RunAsync(cts.Token));
+        Assert.That(chunksWritten, Is.GreaterThanOrEqualTo(3));
+        Assert.That(chunksWritten, Is.LessThan(50));
+    }
+
+    #endregion
+
+    #region 10 — Completed DB job produces zero items on re-run (PostgreSQL)
+
+    [Test]
+    public async Task Completed_db_job_produces_zero_items_on_rerun_PostgreSql()
+    {
+        var jobName = UniqueJobName();
+
+        var writer1 = new CollectingWriter<TestRecord>();
+        await using (var ctx1 = new TestDbContext(PgOptions))
+        {
+            var job1 = Job.CreateBuilder(jobName)
+                .UseJobStore(ConnectionString, DatabaseProvider.PostgreSql)
+                .AddStep("step1", step => step
+                    .ReadFrom(new DbReader<TestRecord>(ctx1, q => q.OrderBy(r => r.Id)))
+                    .WriteTo(writer1)
+                    .WithChunkSize(5000))
+                .Build();
+
+            var result1 = await job1.RunAsync();
+            Assert.That(result1.Success, Is.True);
+            Assert.That(writer1.Written, Has.Count.EqualTo(50_000));
+        }
+
+        var writer2 = new CollectingWriter<TestRecord>();
+        await using (var ctx2 = new TestDbContext(PgOptions))
+        {
+            var job2 = Job.CreateBuilder(jobName)
+                .UseJobStore(ConnectionString, DatabaseProvider.PostgreSql)
+                .AddStep("step1", step => step
+                    .ReadFrom(new DbReader<TestRecord>(ctx2, q => q.OrderBy(r => r.Id)))
+                    .WriteTo(writer2)
+                    .WithChunkSize(5000))
+                .Build();
+
+            var result2 = await job2.RunAsync();
+            Assert.That(result2.Success, Is.True);
+            Assert.That(result2.Steps[0].ItemsRead, Is.EqualTo(0));
+            Assert.That(writer2.Written, Is.Empty);
+        }
+    }
+
+    #endregion
+}

--- a/src/NBatch.Tests/Integration/SqlServerIntegrationTests.cs
+++ b/src/NBatch.Tests/Integration/SqlServerIntegrationTests.cs
@@ -1,6 +1,9 @@
+using Microsoft.EntityFrameworkCore;
 using NBatch.Core;
 using NBatch.Core.Interfaces;
 using NBatch.Core.Repositories;
+using NBatch.Readers.DbReader;
+using NBatch.Tests.Integration.Fixtures;
 using NUnit.Framework;
 
 namespace NBatch.Tests.Integration;
@@ -81,6 +84,32 @@ internal sealed class SqlServerIntegrationTests
     /// <summary>Generates a unique job name per test to avoid cross-test interference.</summary>
     private static string UniqueJobName([System.Runtime.CompilerServices.CallerMemberName] string caller = "")
         => $"{caller}_{Guid.NewGuid():N}";
+
+    /// <summary>
+    /// A processor that fails after a configurable number of successful items.
+    /// Used to simulate mid-dataset failures for restart tests.
+    /// </summary>
+    private sealed class FailAfterNItemsProcessor<T>(int succeedCount) : IProcessor<T, T>
+    {
+        private int _processed;
+
+        public Task<T> ProcessAsync(T input, CancellationToken cancellationToken = default)
+        {
+            if (_processed >= succeedCount)
+                throw new InvalidOperationException($"Simulated failure after {succeedCount} items");
+            _processed++;
+            return Task.FromResult(input);
+        }
+    }
+
+    private static DbContextOptions<TestDbContext> SqlServerOptions
+        => TestDbContext.ForSqlServer(ConnectionString);
+
+    private async Task TruncateEtlTableAsync()
+    {
+        await using var ctx = new TestDbContext(SqlServerOptions);
+        await ctx.Database.ExecuteSqlRawAsync("DELETE FROM TestRecordEtl");
+    }
 
     #endregion
 
@@ -371,6 +400,428 @@ internal sealed class SqlServerIntegrationTests
         Assert.That(result2.Success, Is.True);
         Assert.That(result2.Steps[0].ItemsRead, Is.EqualTo(0));
         Assert.That(writer2.Written, Is.Empty);
+    }
+
+    #endregion
+
+    #region 7 — Large dataset (50K records from SQL Server DB)
+
+    [Test]
+    public async Task Large_dataset_50K_records_chunk500_SqlServer()
+    {
+        await using var ctx = new TestDbContext(SqlServerOptions);
+        var writer = new CollectingWriter<TestRecord>();
+
+        var job = Job.CreateBuilder(UniqueJobName())
+            .UseJobStore(ConnectionString, DatabaseProvider.SqlServer)
+            .AddStep("read-all", step => step
+                .ReadFrom(new DbReader<TestRecord>(ctx, q => q.OrderBy(r => r.Id)))
+                .WriteTo(writer)
+                .WithChunkSize(500))
+            .Build();
+
+        var result = await job.RunAsync();
+
+        Assert.That(result.Success, Is.True);
+        Assert.That(result.Steps[0].ItemsRead, Is.EqualTo(50_000));
+        Assert.That(result.Steps[0].ItemsProcessed, Is.EqualTo(50_000));
+        Assert.That(writer.Written, Has.Count.EqualTo(50_000));
+        Assert.That(writer.Written[0].Code, Is.EqualTo("REC-00001"));
+        Assert.That(writer.Written[^1].Code, Is.EqualTo("REC-50000"));
+    }
+
+    [Test]
+    public async Task Large_dataset_exact_chunk_boundary_chunk1000_SqlServer()
+    {
+        await using var ctx = new TestDbContext(SqlServerOptions);
+        var writer = new CollectingWriter<TestRecord>();
+
+        var job = Job.CreateBuilder(UniqueJobName())
+            .UseJobStore(ConnectionString, DatabaseProvider.SqlServer)
+            .AddStep("read-all", step => step
+                .ReadFrom(new DbReader<TestRecord>(ctx, q => q.OrderBy(r => r.Id)))
+                .WriteTo(writer)
+                .WithChunkSize(1000))
+            .Build();
+
+        var result = await job.RunAsync();
+
+        Assert.That(result.Success, Is.True);
+        Assert.That(writer.Written, Has.Count.EqualTo(50_000));
+    }
+
+    [Test]
+    public async Task Large_dataset_uneven_chunk_boundary_chunk499_SqlServer()
+    {
+        await using var ctx = new TestDbContext(SqlServerOptions);
+        var writer = new CollectingWriter<TestRecord>();
+
+        // 50000 / 499 = 100 full chunks + 1 partial chunk of 100 items
+        var job = Job.CreateBuilder(UniqueJobName())
+            .UseJobStore(ConnectionString, DatabaseProvider.SqlServer)
+            .AddStep("read-all", step => step
+                .ReadFrom(new DbReader<TestRecord>(ctx, q => q.OrderBy(r => r.Id)))
+                .WriteTo(writer)
+                .WithChunkSize(499))
+            .Build();
+
+        var result = await job.RunAsync();
+
+        Assert.That(result.Success, Is.True);
+        Assert.That(writer.Written, Has.Count.EqualTo(50_000));
+    }
+
+    [Test]
+    public async Task Large_dataset_single_chunk_SqlServer()
+    {
+        await using var ctx = new TestDbContext(SqlServerOptions);
+        var writer = new CollectingWriter<TestRecord>();
+
+        var job = Job.CreateBuilder(UniqueJobName())
+            .UseJobStore(ConnectionString, DatabaseProvider.SqlServer)
+            .AddStep("read-all", step => step
+                .ReadFrom(new DbReader<TestRecord>(ctx, q => q.OrderBy(r => r.Id)))
+                .WriteTo(writer)
+                .WithChunkSize(50_000))
+            .Build();
+
+        var result = await job.RunAsync();
+
+        Assert.That(result.Success, Is.True);
+        Assert.That(writer.Written, Has.Count.EqualTo(50_000));
+    }
+
+    [Test]
+    public async Task Large_dataset_oversized_chunk_SqlServer()
+    {
+        await using var ctx = new TestDbContext(SqlServerOptions);
+        var writer = new CollectingWriter<TestRecord>();
+
+        // Chunk size larger than dataset — still processes all 50K in one chunk
+        var job = Job.CreateBuilder(UniqueJobName())
+            .UseJobStore(ConnectionString, DatabaseProvider.SqlServer)
+            .AddStep("read-all", step => step
+                .ReadFrom(new DbReader<TestRecord>(ctx, q => q.OrderBy(r => r.Id)))
+                .WriteTo(writer)
+                .WithChunkSize(100_000))
+            .Build();
+
+        var result = await job.RunAsync();
+
+        Assert.That(result.Success, Is.True);
+        Assert.That(writer.Written, Has.Count.EqualTo(50_000));
+    }
+
+    [Test]
+    public async Task Large_dataset_filtered_by_category_SqlServer()
+    {
+        await using var ctx = new TestDbContext(SqlServerOptions);
+        var writer = new CollectingWriter<TestRecord>();
+
+        // "Alpha" = every 5th record (n % 5 == 0) → 10,000 records
+        var job = Job.CreateBuilder(UniqueJobName())
+            .UseJobStore(ConnectionString, DatabaseProvider.SqlServer)
+            .AddStep("read-alpha", step => step
+                .ReadFrom(new DbReader<TestRecord>(ctx, q => q.Where(r => r.Category == "Alpha").OrderBy(r => r.Id)))
+                .WriteTo(writer)
+                .WithChunkSize(500))
+            .Build();
+
+        var result = await job.RunAsync();
+
+        Assert.That(result.Success, Is.True);
+        Assert.That(writer.Written, Has.Count.EqualTo(10_000));
+        Assert.That(writer.Written.All(r => r.Category == "Alpha"), Is.True);
+    }
+
+    [Test]
+    public async Task Large_dataset_empty_result_set_SqlServer()
+    {
+        await using var ctx = new TestDbContext(SqlServerOptions);
+        var writer = new CollectingWriter<TestRecord>();
+
+        // Query for a category that doesn't exist → 0 records
+        var job = Job.CreateBuilder(UniqueJobName())
+            .UseJobStore(ConnectionString, DatabaseProvider.SqlServer)
+            .AddStep("read-none", step => step
+                .ReadFrom(new DbReader<TestRecord>(ctx, q => q.Where(r => r.Category == "NonExistent").OrderBy(r => r.Id)))
+                .WriteTo(writer)
+                .WithChunkSize(500))
+            .Build();
+
+        var result = await job.RunAsync();
+
+        Assert.That(result.Success, Is.True);
+        Assert.That(result.Steps[0].ItemsRead, Is.EqualTo(0));
+        Assert.That(writer.Written, Is.Empty);
+    }
+
+    #endregion
+
+    #region 8 — Large dataset with transformation
+
+    [Test]
+    public async Task Large_dataset_with_processor_SqlServer()
+    {
+        await using var ctx = new TestDbContext(SqlServerOptions);
+        var writer = new CollectingWriter<TestRecordEtl>();
+
+        var job = Job.CreateBuilder(UniqueJobName())
+            .UseJobStore(ConnectionString, DatabaseProvider.SqlServer)
+            .AddStep("transform", step => step
+                .ReadFrom(new DbReader<TestRecord>(ctx, q => q.OrderBy(r => r.Id)))
+                .ProcessWith(r => new TestRecordEtl
+                {
+                    Code = r.Code.ToUpperInvariant(),
+                    Value = r.Value * 2,
+                    Category = r.Category
+                })
+                .WriteTo(writer)
+                .WithChunkSize(1000))
+            .Build();
+
+        var result = await job.RunAsync();
+
+        Assert.That(result.Success, Is.True);
+        Assert.That(writer.Written, Has.Count.EqualTo(50_000));
+        Assert.That(writer.Written[0].Code, Is.EqualTo("REC-00001"));
+        Assert.That(writer.Written[0].Value, Is.EqualTo(1.23m * 2));
+    }
+
+    #endregion
+
+    #region 9 — Large dataset restart and skip
+
+    [Test]
+    public async Task Large_dataset_restart_from_processor_failure_SqlServer()
+    {
+        var jobName = UniqueJobName();
+
+        // Run 1: processor fails after 5000 items (5 full chunks of 1000).
+        // The 6th chunk fails, job stops.
+        var writer1 = new CollectingWriter<TestRecord>();
+        await using (var ctx1 = new TestDbContext(SqlServerOptions))
+        {
+            var job1 = Job.CreateBuilder(jobName)
+                .UseJobStore(ConnectionString, DatabaseProvider.SqlServer)
+                .AddStep("step1", step => step
+                    .ReadFrom(new DbReader<TestRecord>(ctx1, q => q.OrderBy(r => r.Id)))
+                    .ProcessWith(new FailAfterNItemsProcessor<TestRecord>(succeedCount: 5000))
+                    .WriteTo(writer1)
+                    .WithChunkSize(1000))
+                .Build();
+
+            var result1 = await job1.RunAsync();
+            Assert.That(result1.Success, Is.False);
+            Assert.That(writer1.Written, Has.Count.EqualTo(5000));
+        }
+
+        // Run 2: fresh processor (no failures). Resumes from chunk 6 onward.
+        var writer2 = new CollectingWriter<TestRecord>();
+        await using (var ctx2 = new TestDbContext(SqlServerOptions))
+        {
+            var job2 = Job.CreateBuilder(jobName)
+                .UseJobStore(ConnectionString, DatabaseProvider.SqlServer)
+                .AddStep("step1", step => step
+                    .ReadFrom(new DbReader<TestRecord>(ctx2, q => q.OrderBy(r => r.Id)))
+                    .WriteTo(writer2)
+                    .WithChunkSize(1000))
+                .Build();
+
+            var result2 = await job2.RunAsync();
+            Assert.That(result2.Success, Is.True);
+            Assert.That(writer2.Written, Has.Count.EqualTo(45_000));
+            Assert.That(writer2.Written[0].Code, Is.EqualTo("REC-05001"));
+        }
+    }
+
+    [Test]
+    public async Task Large_dataset_skip_policy_with_db_reader_SqlServer()
+    {
+        await using var ctx = new TestDbContext(SqlServerOptions);
+        var writer = new CollectingWriter<TestRecord>();
+
+        // Processor fails on first 3 items, then succeeds.
+        // With chunk size 1 and skip limit 5, first 3 chunks are skipped.
+        var skipPolicy = new SkipPolicy([typeof(TimeoutException)], skipLimit: 5);
+        var processor = new FailNTimesProcessor<TestRecord>(failCount: 3);
+
+        // Use a small filtered subset (first 10 records) to keep the test fast
+        var job = Job.CreateBuilder(UniqueJobName())
+            .UseJobStore(ConnectionString, DatabaseProvider.SqlServer)
+            .AddStep("step1", step => step
+                .ReadFrom(new DbReader<TestRecord>(ctx, q => q.OrderBy(r => r.Id).Take(10)))
+                .ProcessWith(processor)
+                .WriteTo(writer)
+                .WithSkipPolicy(skipPolicy)
+                .WithChunkSize(1))
+            .Build();
+
+        var result = await job.RunAsync();
+
+        Assert.That(result.Success, Is.True);
+        Assert.That(result.Steps[0].ErrorsSkipped, Is.EqualTo(3));
+        Assert.That(writer.Written, Has.Count.EqualTo(7));
+    }
+
+    #endregion
+
+    #region 10 — Large dataset DB-to-DB ETL within SQL Server
+
+    [Test]
+    public async Task Large_dataset_db_to_db_etl_within_SqlServer()
+    {
+        await TruncateEtlTableAsync();
+
+        await using var readCtx = new TestDbContext(SqlServerOptions);
+
+        var job = Job.CreateBuilder(UniqueJobName())
+            .UseJobStore(ConnectionString, DatabaseProvider.SqlServer)
+            .AddStep("etl", step => step
+                .ReadFrom(new DbReader<TestRecord>(readCtx, q => q.OrderBy(r => r.Id)))
+                .ProcessWith(r => new TestRecordEtl
+                {
+                    Code = r.Code.ToUpperInvariant(),
+                    Value = r.Value * 2,
+                    Category = r.Category
+                })
+                .WriteTo(async (IEnumerable<TestRecordEtl> items, CancellationToken ct) =>
+                {
+                    await using var writeCtx = new TestDbContext(SqlServerOptions);
+                    writeCtx.Set<TestRecordEtl>().AddRange(items);
+                    await writeCtx.SaveChangesAsync(ct);
+                })
+                .WithChunkSize(1000))
+            .Build();
+
+        var result = await job.RunAsync();
+        Assert.That(result.Success, Is.True);
+        Assert.That(result.Steps[0].ItemsProcessed, Is.EqualTo(50_000));
+
+        // Verify data in the ETL table
+        await using var verifyCtx = new TestDbContext(SqlServerOptions);
+        var etlCount = await verifyCtx.TestRecordEtls.CountAsync();
+        Assert.That(etlCount, Is.EqualTo(50_000));
+
+        var first = await verifyCtx.TestRecordEtls.OrderBy(r => r.Id).FirstAsync();
+        Assert.That(first.Code, Is.EqualTo("REC-00001"));
+        Assert.That(first.Value, Is.EqualTo(1.23m * 2));
+
+        await TruncateEtlTableAsync();
+    }
+
+    #endregion
+
+    #region 11 — Cancellation
+
+    [Test]
+    public async Task Cancellation_stops_large_job_SqlServer()
+    {
+        await using var ctx = new TestDbContext(SqlServerOptions);
+        var cts = new CancellationTokenSource();
+        int chunksWritten = 0;
+
+        var job = Job.CreateBuilder(UniqueJobName())
+            .UseJobStore(ConnectionString, DatabaseProvider.SqlServer)
+            .AddStep("read-all", step => step
+                .ReadFrom(new DbReader<TestRecord>(ctx, q => q.OrderBy(r => r.Id)))
+                .WriteTo(async (IEnumerable<TestRecord> items, CancellationToken ct) =>
+                {
+                    if (Interlocked.Increment(ref chunksWritten) >= 3)
+                        await cts.CancelAsync();
+                })
+                .WithChunkSize(1000))
+            .Build();
+
+        Assert.ThrowsAsync<OperationCanceledException>(() => job.RunAsync(cts.Token));
+        Assert.That(chunksWritten, Is.GreaterThanOrEqualTo(3));
+        Assert.That(chunksWritten, Is.LessThan(50));
+    }
+
+    #endregion
+
+    #region 12 — Completed DB job produces zero items on re-run
+
+    [Test]
+    public async Task Completed_db_job_produces_zero_items_on_rerun_SqlServer()
+    {
+        var jobName = UniqueJobName();
+
+        var writer1 = new CollectingWriter<TestRecord>();
+        await using (var ctx1 = new TestDbContext(SqlServerOptions))
+        {
+            var job1 = Job.CreateBuilder(jobName)
+                .UseJobStore(ConnectionString, DatabaseProvider.SqlServer)
+                .AddStep("step1", step => step
+                    .ReadFrom(new DbReader<TestRecord>(ctx1, q => q.OrderBy(r => r.Id)))
+                    .WriteTo(writer1)
+                    .WithChunkSize(5000))
+                .Build();
+
+            var result1 = await job1.RunAsync();
+            Assert.That(result1.Success, Is.True);
+            Assert.That(writer1.Written, Has.Count.EqualTo(50_000));
+        }
+
+        // Run 2: same job name → resumes past all data, reads 0 items
+        var writer2 = new CollectingWriter<TestRecord>();
+        await using (var ctx2 = new TestDbContext(SqlServerOptions))
+        {
+            var job2 = Job.CreateBuilder(jobName)
+                .UseJobStore(ConnectionString, DatabaseProvider.SqlServer)
+                .AddStep("step1", step => step
+                    .ReadFrom(new DbReader<TestRecord>(ctx2, q => q.OrderBy(r => r.Id)))
+                    .WriteTo(writer2)
+                    .WithChunkSize(5000))
+                .Build();
+
+            var result2 = await job2.RunAsync();
+            Assert.That(result2.Success, Is.True);
+            Assert.That(result2.Steps[0].ItemsRead, Is.EqualTo(0));
+            Assert.That(writer2.Written, Is.Empty);
+        }
+    }
+
+    #endregion
+
+    #region 13 — Multi-step with DB reader and tasklet
+
+    [Test]
+    public async Task Multi_step_db_read_transform_then_tasklet_SqlServer()
+    {
+        var writer = new CollectingWriter<TestRecordEtl>();
+        bool taskletExecuted = false;
+
+        await using var ctx = new TestDbContext(SqlServerOptions);
+
+        var job = Job.CreateBuilder(UniqueJobName())
+            .UseJobStore(ConnectionString, DatabaseProvider.SqlServer)
+            .AddStep("transform", step => step
+                .ReadFrom(new DbReader<TestRecord>(ctx,
+                    q => q.Where(r => r.Category == "Beta").OrderBy(r => r.Id)))
+                .ProcessWith(r => new TestRecordEtl
+                {
+                    Code = r.Code.ToUpperInvariant(),
+                    Value = r.Value,
+                    Category = r.Category
+                })
+                .WriteTo(writer)
+                .WithChunkSize(1000))
+            .AddStep("notify", step => step
+                .Execute(() =>
+                {
+                    taskletExecuted = true;
+                    return Task.CompletedTask;
+                }))
+            .Build();
+
+        var result = await job.RunAsync();
+
+        Assert.That(result.Success, Is.True);
+        Assert.That(result.Steps, Has.Count.EqualTo(2));
+        Assert.That(writer.Written, Has.Count.EqualTo(10_000));
+        Assert.That(writer.Written.All(r => r.Category == "Beta"), Is.True);
+        Assert.That(taskletExecuted, Is.True);
     }
 
     #endregion

--- a/src/NBatch.Tests/Scripts/init-postgres.sql
+++ b/src/NBatch.Tests/Scripts/init-postgres.sql
@@ -1,0 +1,42 @@
+-- =============================================================================
+-- Integration test seed data for PostgreSQL.
+-- Creates a TestRecord table with 50,000 deterministic rows and an empty
+-- TestRecordEtl table for cross-database ETL tests.
+--
+-- Executed automatically by docker-entrypoint-initdb.d on first start.
+-- Target database: nbatch_integration (created by POSTGRES_DB env var).
+-- =============================================================================
+
+-- Source table: 50,000 deterministic test records
+CREATE TABLE IF NOT EXISTS "TestRecord"
+(
+    "Id"       SERIAL         PRIMARY KEY,
+    "Code"     VARCHAR(50)    NOT NULL,
+    "Value"    DECIMAL(18, 2) NOT NULL,
+    "Category" VARCHAR(50)    NOT NULL
+);
+
+-- ETL destination table (populated by cross-database tests, cleaned between runs)
+CREATE TABLE IF NOT EXISTS "TestRecordEtl"
+(
+    "Id"       SERIAL         PRIMARY KEY,
+    "Code"     VARCHAR(50)    NOT NULL,
+    "Value"    DECIMAL(18, 2) NOT NULL,
+    "Category" VARCHAR(50)    NOT NULL
+);
+
+-- Seed 50,000 rows if the table is empty.
+-- 5 categories × 10,000 rows each for filtered-read tests.
+INSERT INTO "TestRecord" ("Code", "Value", "Category")
+SELECT
+    'REC-' || LPAD(n::TEXT, 5, '0'),
+    ROUND((n * 1.23)::NUMERIC, 2),
+    CASE (n % 5)
+        WHEN 0 THEN 'Alpha'
+        WHEN 1 THEN 'Beta'
+        WHEN 2 THEN 'Gamma'
+        WHEN 3 THEN 'Delta'
+        WHEN 4 THEN 'Epsilon'
+    END
+FROM generate_series(1, 50000) AS s(n)
+WHERE NOT EXISTS (SELECT 1 FROM "TestRecord" LIMIT 1);

--- a/src/NBatch.Tests/Scripts/init-sqlserver.sql
+++ b/src/NBatch.Tests/Scripts/init-sqlserver.sql
@@ -1,0 +1,62 @@
+-- =============================================================================
+-- Integration test seed data for SQL Server.
+-- Creates the NBatch_IntegrationTests database with a TestRecord table
+-- containing 50,000 deterministic rows and an empty TestRecordEtl table
+-- for cross-database ETL tests.
+--
+-- Executed automatically by docker-compose on first start.
+-- =============================================================================
+
+IF DB_ID('NBatch_IntegrationTests') IS NULL
+    CREATE DATABASE NBatch_IntegrationTests;
+GO
+
+USE NBatch_IntegrationTests;
+GO
+
+-- Source table: 50,000 deterministic test records
+IF OBJECT_ID('TestRecord', 'U') IS NULL
+CREATE TABLE TestRecord
+(
+    Id       INT            NOT NULL IDENTITY(1,1) PRIMARY KEY,
+    Code     NVARCHAR(50)   NOT NULL,
+    Value    DECIMAL(18, 2) NOT NULL,
+    Category NVARCHAR(50)   NOT NULL
+);
+GO
+
+-- ETL destination table (populated by cross-database tests, cleaned between runs)
+IF OBJECT_ID('TestRecordEtl', 'U') IS NULL
+CREATE TABLE TestRecordEtl
+(
+    Id       INT            NOT NULL IDENTITY(1,1) PRIMARY KEY,
+    Code     NVARCHAR(50)   NOT NULL,
+    Value    DECIMAL(18, 2) NOT NULL,
+    Category NVARCHAR(50)   NOT NULL
+);
+GO
+
+-- Seed 50,000 rows if the table is empty.
+-- 5 categories × 10,000 rows each for filtered-read tests.
+IF NOT EXISTS (SELECT 1 FROM TestRecord)
+BEGIN
+    ;WITH Numbers AS (
+        SELECT 1 AS n
+        UNION ALL
+        SELECT n + 1 FROM Numbers WHERE n < 50000
+    )
+    INSERT INTO TestRecord (Code, Value, Category)
+    SELECT
+        'REC-' + RIGHT('00000' + CAST(n AS VARCHAR), 5),
+        CAST(n * 1.23 AS DECIMAL(18, 2)),
+        CASE (n % 5)
+            WHEN 0 THEN 'Alpha'
+            WHEN 1 THEN 'Beta'
+            WHEN 2 THEN 'Gamma'
+            WHEN 3 THEN 'Delta'
+            WHEN 4 THEN 'Epsilon'
+        END
+    FROM Numbers
+    OPTION (MAXRECURSION 0);
+END
+GO

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -2,6 +2,7 @@ name: nbatch
 
 volumes:
   sqlserver_data:
+  postgres_data:
 
 services:
   nbatch.database:
@@ -15,6 +16,7 @@ services:
     volumes:
       - sqlserver_data:/var/opt/mssql
       - ./NBatch.ConsoleApp/Scripts:/scripts:ro
+      - ./NBatch.Tests/Scripts:/test-scripts:ro
     command: >
       bash -c "
       /opt/mssql/bin/sqlservr &
@@ -22,11 +24,32 @@ services:
         sleep 2;
       done;
       /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P \"$$MSSQL_SA_PASSWORD\" -C -i /scripts/init-db.sql;
+      /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P \"$$MSSQL_SA_PASSWORD\" -C -i /test-scripts/init-sqlserver.sql;
+      touch /tmp/init-complete;
       wait
       "
     healthcheck:
-      test: /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "$$MSSQL_SA_PASSWORD" -C -Q "SELECT 1" -b -o /dev/null
+      test: test -f /tmp/init-complete && /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "$$MSSQL_SA_PASSWORD" -C -Q "SELECT 1" -b -o /dev/null
       interval: 10s
       timeout: 5s
       retries: 10
       start_period: 60s
+
+  nbatch.postgres:
+    image: postgres:16
+    container_name: nbatch.postgres
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_USER=nbatch
+      - POSTGRES_PASSWORD=Password1234
+      - POSTGRES_DB=nbatch_integration
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./NBatch.Tests/Scripts/init-postgres.sql:/docker-entrypoint-initdb.d/init.sql:ro
+    healthcheck:
+      test: pg_isready -U nbatch -d nbatch_integration
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s


### PR DESCRIPTION
- Add PostgreSqlIntegrationTests and CrossDatabaseEtlTests for full coverage of NBatch pipelines on PostgreSQL and cross-database ETL scenarios
- Add Dockerized PostgreSQL service with schema/data init scripts (50K test rows, ETL tables) to docker-compose
- Add EF Core test fixtures for shared test entities and context
- Seed both SQL Server and PostgreSQL with identical test data for reliable cross-DB tests
- Update CI and compose to support both DBs and clean up after tests
- Improve job/step progress commit logic to prevent duplicate processing on cancellation
- Refactor error handling for robust cancellation and logging